### PR TITLE
Fix release image deployment

### DIFF
--- a/.github/workflows/on-release-tag.yaml
+++ b/.github/workflows/on-release-tag.yaml
@@ -25,5 +25,4 @@ jobs:
     uses: ./.github/workflows/reusable-deploy-cloud-run.yaml
     secrets: inherit
     with:
-      image: ${{ needs.docker.outputs.tags }}
-
+      image: permissionizer/server@${{ needs.docker.outputs.digest }}


### PR DESCRIPTION
## Summary
- deploy release builds by immutable image digest
- avoid passing newline-separated metadata tags to Cloud Run
- match the image format already used by the main-branch deployment

## Validation
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/on-release-tag.yaml`